### PR TITLE
Feat : 예외 처리에 사용한 CustomException 추가 및 전역 예외 핸들러 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### Custom ###
 application.properties
+application.yml

--- a/src/main/java/com/sparta/cloneproject_be/dto/ExceptionDto.java
+++ b/src/main/java/com/sparta/cloneproject_be/dto/ExceptionDto.java
@@ -1,0 +1,12 @@
+package com.sparta.cloneproject_be.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ExceptionDto {
+    String message;
+
+    public ExceptionDto(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/sparta/cloneproject_be/exception/CustomException.java
+++ b/src/main/java/com/sparta/cloneproject_be/exception/CustomException.java
@@ -1,0 +1,17 @@
+package com.sparta.cloneproject_be.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    int statusCode;
+    String message;
+
+    public CustomException(int statusCode, String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+    }
+
+    // 사용 예시
+    // throw new CustomException(HttpStatus.BAD_REQUEST.value(), ErrorMessage.ENROLLED_EMAIL.getMessage());
+}

--- a/src/main/java/com/sparta/cloneproject_be/exception/ErrorMessage.java
+++ b/src/main/java/com/sparta/cloneproject_be/exception/ErrorMessage.java
@@ -1,0 +1,33 @@
+package com.sparta.cloneproject_be.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorMessage {
+
+    ENROLLED_EMAIL("중복된 이메일입니다."),
+    ENROLLED_NICKNAME("중복된 닉네임입니다."),
+    UNENROLLED_EMAIL("등록되지 않은 이메일입니다."),
+    PASSWORD_MISMATCH("비밀번호를 확인해주세요."),
+    OUT_OF_EMAIL_PATTERN("이메일 양식에 맞지 않습니다."),
+    OUT_OF_PASSWORD_PATTERN("비밀번호 양식에 맞지 않습니다."), // 추후 프론트에서 비밀번호 유효성 검사 패턴을 정해주면 메시지 수정
+    NON_EXIST_POST("존재하지 않는 게시글입니다."),
+    ALREADY_RESERVED("이미 예약되었습니다."),
+
+    CANNOT_DELETE_WISHLIST("직접 찜한 위시리트만 삭제 가능합니다."),
+    CANNOT_CANCLE_RESERVATION("직접 등록한 예약만 취소 가능합니다."),
+    CANNOT_UPDATE_POST("직접 작성한 게시글만 수정 가능합니다."),
+    CANNOT_DELETE_POST("직접 작성한 게시글만 삭제 가능합니다."),
+
+    NOT_IMAGE("jpg, jpeg, png 파일만 업로드 가능합니다."),
+    BLANK_EXIST("입력되지 않은 값이 있습니다. 모든 항목을 작성해주세요."),
+
+    INVALID_TOKEN("유효하지 않은 토큰입니다.");
+
+
+    private String message;
+
+    ErrorMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/sparta/cloneproject_be/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/cloneproject_be/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.sparta.cloneproject_be.exception;
+
+import com.sparta.cloneproject_be.dto.ExceptionDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = {MethodArgumentNotValidException.class})
+    public ResponseEntity<ExceptionDto> handleValidException(MethodArgumentNotValidException ex) {
+        ExceptionDto exceptionDto = new ExceptionDto("유효성 검사를 통과하지 못했습니다.");
+        return ResponseEntity.status(400).body(exceptionDto);
+    }
+
+    @ExceptionHandler(value = {CustomException.class})
+    public ResponseEntity<ExceptionDto> handleCustomException(CustomException ex) {
+        ExceptionDto exceptionDto = new ExceptionDto(ex.getMessage());
+        return ResponseEntity.status(ex.getStatusCode()).body(exceptionDto);
+    }
+}


### PR DESCRIPTION
각자 예외 처리 하실 때 CustomException 클래스로 예외를 던지면 전역 예외 핸들러에서 이를 처리하도록 했습니다.

에러 메시지로 사용할 enum도 추가해뒀으니 자세한 사용 방법은 CustomException 클래스 파일의 주석을 확인해주세요.